### PR TITLE
Configurando o kubernetes do edge-service para produção com implatanç…

### DIFF
--- a/kubernetes/applications/edge-service/production/application-prod.yml
+++ b/kubernetes/applications/edge-service/production/application-prod.yml
@@ -1,0 +1,3 @@
+spring:
+  config:
+    import: configtree:/workspace/secrets/*/

--- a/kubernetes/applications/edge-service/production/kustomize.yml
+++ b/kubernetes/applications/edge-service/production/kustomize.yml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/polar-libraries/edge-service/k8s?ref=main
+
+patchesStrategicMerge:
+  - patch-ingress.yml
+  - patch-env.yml
+  - patch-resources.yml
+  - patch-volumes.yml
+
+configMapGenerator:
+  - behavior: merge
+    files:
+      - application-prod.yml
+    name: edge-config
+
+images:
+  - name: edge-service
+    newName: ghcr.io/polar-libraries/edge-service
+    newTag: latest
+
+replicas:
+  - count: 1
+    name: edge-service

--- a/kubernetes/applications/edge-service/production/patch-env.yml
+++ b/kubernetes/applications/edge-service/production/patch-env.yml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: edge-service
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod

--- a/kubernetes/applications/edge-service/production/patch-ingress.yml
+++ b/kubernetes/applications/edge-service/production/patch-ingress.yml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: polar-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location ~* "^/actuator" {
+        deny all;
+        return 403;
+      }

--- a/kubernetes/applications/edge-service/production/patch-resources.yml
+++ b/kubernetes/applications/edge-service/production/patch-resources.yml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-service
+spec:
+  template:
+    spec:
+      containers:
+        resources:
+          requests:
+            memory: 756mi
+            cpu: "0.1"
+          limits:
+            memory: 756Mi
+            cpu: "2"

--- a/kubernetes/applications/edge-service/production/patch-volumes.yml
+++ b/kubernetes/applications/edge-service/production/patch-volumes.yml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: edge-service
+          volumeMounts:
+            - name: redis-credentials-volume
+              mountPath: /workspace/secrets/postgres
+            - name: keycloak-client-credentials-volume
+              mountPath: /workspace/secrets/keycloak-client
+            - name: keycloak-issuer-client-secret-volume
+              mountPath: /workspace/secrets/keycloak-issuer
+      volumes:
+        - name: redis-credentials-volume
+          secret:
+            secretName: polar-redis-credentials
+        - name: keycloak-client-credentials-volume
+          secret:
+            secretName: polar-keycloak-client-credentials
+        - name: keycloak-issuer-client-secret-volume
+          secret:
+            secretName: keycloak-issuer-client-secret


### PR DESCRIPTION
Configurando o kubernetes do edge-service para produção com implatanção continua notificando o workflow do polar-deployment para atualizar os pods com a nova imagem lançada. Implantação continua quando uma nova imagem candidatata é lançada e implatada automaticamente.